### PR TITLE
Stability improvements, bug fixes

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GradleSettings">
+    <option name="linkedExternalProjectsSettings">
+      <GradleProjectSettings>
+        <compositeConfiguration>
+          <compositeBuild compositeDefinitionSource="SCRIPT" />
+        </compositeConfiguration>
+        <option name="distributionType" value="DEFAULT_WRAPPED" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="modules">
+          <set>
+            <option value="$PROJECT_DIR$" />
+            <option value="$PROJECT_DIR$/app" />
+          </set>
+        </option>
+        <option name="resolveModulePerSourceSet" value="false" />
+        <option name="testRunner" value="PLATFORM" />
+      </GradleProjectSettings>
+    </option>
+  </component>
+</project>

--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RunConfigurationProducerService">
+    <option name="ignoredProducers">
+      <set>
+        <option value="org.jetbrains.plugins.gradle.execution.test.runner.AllInPackageGradleConfigurationProducer" />
+        <option value="org.jetbrains.plugins.gradle.execution.test.runner.TestClassGradleConfigurationProducer" />
+        <option value="org.jetbrains.plugins.gradle.execution.test.runner.TestMethodGradleConfigurationProducer" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/app/app.iml
+++ b/app/app.iml
@@ -19,7 +19,7 @@
         <option name="ALLOW_USER_CONFIGURATION" value="false" />
         <option name="MANIFEST_FILE_RELATIVE_PATH" value="/src/main/AndroidManifest.xml" />
         <option name="RES_FOLDER_RELATIVE_PATH" value="/src/main/res" />
-        <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/src/main/res;file://$MODULE_DIR$/build/generated/fabric/res/debug" />
+        <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/src/main/res;file://$MODULE_DIR$/build/generated/fabric/res/debug;file://$MODULE_DIR$/build/generated/res/resValues/debug" />
         <option name="TEST_RES_FOLDERS_RELATIVE_PATH" value="" />
         <option name="ASSETS_FOLDER_RELATIVE_PATH" value="/src/main/assets" />
       </configuration>

--- a/app/app.iml
+++ b/app/app.iml
@@ -19,7 +19,7 @@
         <option name="ALLOW_USER_CONFIGURATION" value="false" />
         <option name="MANIFEST_FILE_RELATIVE_PATH" value="/src/main/AndroidManifest.xml" />
         <option name="RES_FOLDER_RELATIVE_PATH" value="/src/main/res" />
-        <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/src/main/res;file://$MODULE_DIR$/build/generated/fabric/res/debug;file://$MODULE_DIR$/build/generated/res/resValues/debug" />
+        <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/src/main/res;file://$MODULE_DIR$/build/generated/fabric/res/debug" />
         <option name="TEST_RES_FOLDERS_RELATIVE_PATH" value="" />
         <option name="ASSETS_FOLDER_RELATIVE_PATH" value="/src/main/assets" />
       </configuration>
@@ -103,7 +103,7 @@
     <orderEntry type="library" scope="TEST" name="Gradle: androidx.test:core:1.2.0@aar" level="project" />
     <orderEntry type="library" scope="TEST" name="Gradle: androidx.test:monitor:1.2.0@aar" level="project" />
     <orderEntry type="library" scope="TEST" name="Gradle: androidx.test.espresso:espresso-idling-resource:3.2.0@aar" level="project" />
-    <orderEntry type="library" name="Gradle: __local_aars__:/home/xavier/AndroidStudioProjects/Android-Merchant-App/app/libs/MyWalletHD.jar:unspecified@jar" level="project" />
+    <orderEntry type="library" name="Gradle: __local_aars__:/Users/mark/Documents/Git/Android-Merchant-App/app/libs/MyWalletHD.jar:unspecified@jar" level="project" />
     <orderEntry type="library" name="Gradle: androidx.collection:collection:1.1.0@jar" level="project" />
     <orderEntry type="library" name="Gradle: androidx.lifecycle:lifecycle-common:2.1.0@jar" level="project" />
     <orderEntry type="library" name="Gradle: androidx.arch.core:core-common:2.1.0@jar" level="project" />

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,6 +34,11 @@ android {
             abortOnError false
         }
     }
+    packagingOptions {
+        exclude 'lib/x86_64/darwin/libscrypt.dylib'
+        exclude 'lib/x86_64/freebsd/libscrypt.so'
+        exclude 'lib/x86_64/linux/libscrypt.so'
+    }
 }
 
 dependencies {

--- a/app/src/main/java/com/bitcoin/merchant/app/network/websocket/impl/TxWebSocketHandlerImpl.java
+++ b/app/src/main/java/com/bitcoin/merchant/app/network/websocket/impl/TxWebSocketHandlerImpl.java
@@ -84,10 +84,20 @@ public abstract class TxWebSocketHandlerImpl implements TxWebSocketHandler {
 
         @Override
         public void run() {
-            try {
-                handler = new ConnectionHandler();
-            } catch (Exception e) {
-                Log.e(TAG, "Connect", e);
+            long doubleBackOff = 1000;
+            while (true) {
+                try {
+                    handler = new ConnectionHandler();
+                    break;
+                } catch (Exception e) {
+                    Log.e(TAG, "Connect", e);
+                    try {
+                        Thread.sleep(doubleBackOff);
+                    } catch (InterruptedException ex) {
+                        // fail silently
+                    }
+                    doubleBackOff *= 2;
+                }
             }
         }
     }

--- a/app/src/main/java/com/bitcoin/merchant/app/screens/SettingsActivity.java
+++ b/app/src/main/java/com/bitcoin/merchant/app/screens/SettingsActivity.java
@@ -31,10 +31,14 @@ import com.bitcoin.merchant.app.currency.CurrencyExchange;
 import com.bitcoin.merchant.app.screens.dialogs.AddNewAddressDialog;
 import com.bitcoin.merchant.app.screens.dialogs.CurrencySelectionDialog;
 import com.bitcoin.merchant.app.screens.dialogs.MerchantNameEditorDialog;
+import com.bitcoin.merchant.app.util.AddressUtil;
 import com.bitcoin.merchant.app.util.AppUtil;
 import com.bitcoin.merchant.app.util.PrefsUtil;
 import com.bitcoin.merchant.app.util.ToastCustom;
 import com.google.bitcoin.uri.BitcoinCashURI;
+
+import de.tobibrandt.bitcoincash.BitcoinCashAddressFormatter;
+import info.blockchain.wallet.util.FormatsUtil;
 
 public class SettingsActivity extends PreferenceActivity {
     public static final String SCAN_RESULT = "SCAN_RESULT";
@@ -219,12 +223,8 @@ public class SettingsActivity extends PreferenceActivity {
         super.onActivityResult(requestCode, resultCode, data);
         if ((resultCode == Activity.RESULT_OK) && (requestCode == ZBAR_SCANNER_REQUEST) && (data != null)) {
             Log.v(TAG, "requestCode:" + requestCode + ", resultCode:" + resultCode + ", Intent:" + data.getStringExtra(SCAN_RESULT));
-            String address = BitcoinCashURI.toLegacyAddress(data.getStringExtra(SCAN_RESULT));
-            if (AppUtil.isValidAddress(address)) {
-                setNewAddress(address);
-            } else {
-                ToastCustom.makeText(this, getString(R.string.unrecognized_xpub), ToastCustom.LENGTH_SHORT, ToastCustom.TYPE_ERROR);
-            }
+            System.out.println("ADDRESS SCANNED: " + data.getStringExtra(SCAN_RESULT));
+            validateThenSetNewAddress(data.getStringExtra(SCAN_RESULT));
         } else {
             Log.v(TAG, "requestCode:" + requestCode + ", resultCode:" + resultCode);
         }
@@ -233,6 +233,54 @@ public class SettingsActivity extends PreferenceActivity {
     public void setNewAddress(String receiver) {
         newAddressPref.setSummary(AppUtil.convertToBitcoinCash(receiver));
         AppUtil.setReceivingAddress(this, receiver);
+    }
+
+    public void validateThenSetNewAddress(String address) {
+        final SettingsActivity ctx = SettingsActivity.this;
+        if (AppUtil.isValidAddress(address)) {
+            /*
+            If it's not a valid xpub, we can assume it's a Bitcoin Cash address since the address is valid from the previous if statement.
+             */
+            if (!FormatsUtil.getInstance().isValidXpub(address)) {
+                if (AddressUtil.isValidCashAddr(address)) {
+                    String cashAddrPrefix = BitcoinCashAddressFormatter.MAIN_NET_PREFIX + ":";
+                    if (!address.startsWith(cashAddrPrefix))
+                        address = cashAddrPrefix + address;
+                }
+                setNewAddress(address);
+            } else {
+                setNewAddress(address);
+
+                /*
+                When a merchant sets an xpub as their address in the settings, we want to sync the wallet up to the freshest address so users won't be sending to older addresses.
+                We do this by polling Bitcoin.com's REST API for the address history of all addresses up until we find a fresh address.
+
+                Due to Android forcing networking to be on a separate thread, we do this in a thread.
+                 */
+                new Thread() {
+                    @Override
+                    public void run() {
+                        AppUtil util = AppUtil.getInstance(ctx);
+                        try {
+                            boolean synced = util.getWallet().syncXpub();
+                            if (synced) {
+                                ctx.runOnUiThread(new Runnable() {
+                                    @Override
+                                    public void run() {
+                                        ToastCustom.makeText(ctx, ctx.getString(R.string.synced_xpub), ToastCustom.LENGTH_SHORT, ToastCustom.TYPE_OK);
+                                    }
+                                });
+                            }
+                        } catch (Exception e) {
+                            e.printStackTrace();
+                        }
+                    }
+                }.start();
+                ToastCustom.makeText(ctx, ctx.getString(R.string.syncing_xpub), ToastCustom.LENGTH_SHORT, ToastCustom.TYPE_GENERAL);
+            }
+        } else {
+            ToastCustom.makeText(ctx, ctx.getString(R.string.unrecognized_xpub), ToastCustom.LENGTH_SHORT, ToastCustom.TYPE_ERROR);
+        }
     }
 
     @Override

--- a/app/src/main/java/com/bitcoin/merchant/app/screens/SettingsActivity.java
+++ b/app/src/main/java/com/bitcoin/merchant/app/screens/SettingsActivity.java
@@ -237,50 +237,69 @@ public class SettingsActivity extends PreferenceActivity {
 
     public void validateThenSetNewAddress(String address) {
         final SettingsActivity ctx = SettingsActivity.this;
+        //Is this a valid xpub, legacy, or cashaddr?
         if (AppUtil.isValidAddress(address)) {
             /*
             If it's not a valid xpub, we can assume it's a Bitcoin Cash address since the address is valid from the previous if statement.
              */
             if (!FormatsUtil.getInstance().isValidXpub(address)) {
-                if (AddressUtil.isValidCashAddr(address)) {
-                    String cashAddrPrefix = BitcoinCashAddressFormatter.MAIN_NET_PREFIX + ":";
-                    if (!address.startsWith(cashAddrPrefix))
-                        address = cashAddrPrefix + address;
-                }
-                setNewAddress(address);
+                //legacy or cashaddr logic.
+                this.validateCashaddrOrLegacyAddress(address);
             } else {
-                setNewAddress(address);
-
-                /*
-                When a merchant sets an xpub as their address in the settings, we want to sync the wallet up to the freshest address so users won't be sending to older addresses.
-                We do this by polling Bitcoin.com's REST API for the address history of all addresses up until we find a fresh address.
-
-                Due to Android forcing networking to be on a separate thread, we do this in a thread.
-                 */
-                new Thread() {
-                    @Override
-                    public void run() {
-                        AppUtil util = AppUtil.getInstance(ctx);
-                        try {
-                            boolean synced = util.getWallet().syncXpub();
-                            if (synced) {
-                                ctx.runOnUiThread(new Runnable() {
-                                    @Override
-                                    public void run() {
-                                        ToastCustom.makeText(ctx, ctx.getString(R.string.synced_xpub), ToastCustom.LENGTH_SHORT, ToastCustom.TYPE_OK);
-                                    }
-                                });
-                            }
-                        } catch (Exception e) {
-                            e.printStackTrace();
-                        }
-                    }
-                }.start();
-                ToastCustom.makeText(ctx, ctx.getString(R.string.syncing_xpub), ToastCustom.LENGTH_SHORT, ToastCustom.TYPE_GENERAL);
+                //xpub logic
+                this.saveXpubAsDestinationAddress(address);
+                this.beginSyncingXpubWallet(ctx);
             }
         } else {
+            //If it is not valid, then display to the user that they did not enter a valid xpub, or legacy/cashaddr address.
             ToastCustom.makeText(ctx, ctx.getString(R.string.unrecognized_xpub), ToastCustom.LENGTH_SHORT, ToastCustom.TYPE_ERROR);
         }
+    }
+
+    private void validateCashaddrOrLegacyAddress(String address) {
+        //First we check if it's a cashaddr
+        if (AddressUtil.isValidCashAddr(address)) {
+            //Then we check if it has the bitcoincash: prefix, if it doesn't then we add it
+            String cashAddrPrefix = BitcoinCashAddressFormatter.MAIN_NET_PREFIX + ":";
+            if (!address.startsWith(cashAddrPrefix))
+                address = cashAddrPrefix + address;
+        }
+        //Then we set the address.
+        setNewAddress(address);
+    }
+
+    private void saveXpubAsDestinationAddress(String xpub)
+    {
+        setNewAddress(xpub);
+    }
+
+    private void beginSyncingXpubWallet(final SettingsActivity ctx) {
+        /*
+        When a merchant sets an xpub as their address in the settings, we want to sync the wallet up to the freshest address so users won't be sending to older addresses.
+        We do this by polling Bitcoin.com's REST API for the address history of all addresses up until we find a fresh address.
+
+        Due to Android forcing networking to be on a separate thread, we do this in a thread.
+         */
+        new Thread() {
+            @Override
+            public void run() {
+                AppUtil util = AppUtil.getInstance(ctx);
+                try {
+                    boolean synced = util.getWallet().syncXpub();
+                    if (synced) {
+                        ctx.runOnUiThread(new Runnable() {
+                            @Override
+                            public void run() {
+                                ToastCustom.makeText(ctx, ctx.getString(R.string.synced_xpub), ToastCustom.LENGTH_SHORT, ToastCustom.TYPE_OK);
+                            }
+                        });
+                    }
+                } catch (Exception e) {
+                    Log.e(TAG, "", e);
+                }
+            }
+        }.start();
+        ToastCustom.makeText(ctx, ctx.getString(R.string.syncing_xpub), ToastCustom.LENGTH_SHORT, ToastCustom.TYPE_GENERAL);
     }
 
     @Override

--- a/app/src/main/java/com/bitcoin/merchant/app/screens/dialogs/AddNewAddressDialog.java
+++ b/app/src/main/java/com/bitcoin/merchant/app/screens/dialogs/AddNewAddressDialog.java
@@ -8,8 +8,6 @@ import android.widget.TextView;
 import com.bitcoin.merchant.app.R;
 import com.bitcoin.merchant.app.screens.SettingsActivity;
 import com.bitcoin.merchant.app.util.AppUtil;
-import com.bitcoin.merchant.app.util.ToastCustom;
-import com.google.bitcoin.uri.BitcoinCashURI;
 
 public class AddNewAddressDialog {
     private final SettingsActivity ctx;
@@ -49,7 +47,7 @@ public class AddNewAddressDialog {
                 .setCancelable(false)
                 .setPositiveButton(R.string.prompt_ok, new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int whichButton) {
-                        validateThenSetNewAddress(etReceiver.getText().toString().trim());
+                        ctx.validateThenSetNewAddress(etReceiver.getText().toString().trim());
                         dialog.dismiss();
                     }
                 })
@@ -61,22 +59,13 @@ public class AddNewAddressDialog {
                 .show();
     }
 
-    private void validateThenSetNewAddress(String address) {
-        address = BitcoinCashURI.toLegacyAddress(address);
-        if (AppUtil.isValidAddress(address)) {
-            ctx.setNewAddress(address);
-        } else {
-            ToastCustom.makeText(ctx, ctx.getString(R.string.unrecognized_xpub), ToastCustom.LENGTH_SHORT, ToastCustom.TYPE_ERROR);
-        }
-    }
-
     private void enterAddressUsingInputField() {
         if (ENTERING_ADDRESS_BYPASSED) {
             ctx.setNewAddress("1MxRuANd5CmHWcveTwQaAJ36sStEQ5QM5k");
         } else {
             final EditText etReceiver = new EditText(ctx);
             etReceiver.setSingleLine(true);
-            etReceiver.setText(AppUtil.getReceivingAddress(ctx));
+            etReceiver.setText(AppUtil.convertToBitcoinCash(AppUtil.getReceivingAddress(ctx)));
             showDialogToEnterAddress(etReceiver);
         }
     }

--- a/app/src/main/java/com/bitcoin/merchant/app/util/AddressUtil.java
+++ b/app/src/main/java/com/bitcoin/merchant/app/util/AddressUtil.java
@@ -1,0 +1,26 @@
+package com.bitcoin.merchant.app.util;
+
+import com.github.kiulian.converter.AddressConverter;
+import com.github.kiulian.converter.b58.B58;
+
+import de.tobibrandt.bitcoincash.BitcoinCashAddressFormatter;
+
+public class AddressUtil {
+
+    public static boolean isValidCashAddr(String address) {
+        return BitcoinCashAddressFormatter.isValidCashAddress(address);
+    }
+
+    public static boolean isValidLegacy(String address) {
+        try {
+            B58.decodeAndCheck(address);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public static String toCashAddress(String legacy) {
+        return AddressConverter.toCashAddress(legacy);
+    }
+}

--- a/app/src/main/java/com/bitcoin/merchant/app/util/AppUtil.java
+++ b/app/src/main/java/com/bitcoin/merchant/app/util/AppUtil.java
@@ -58,9 +58,7 @@ public class AppUtil {
     }
 
     public static boolean isValidAddress(String address) {
-        return (address != null && address.length() > 0)
-                && (FormatsUtil.getInstance().isValidXpub(address)
-                || FormatsUtil.getInstance().isValidBitcoinAddress(address));
+        return (address != null && address.length() > 0) && (FormatsUtil.getInstance().isValidXpub(address) || AddressUtil.isValidCashAddr(address) || AddressUtil.isValidLegacy(address));
     }
 
     public static String getCurrency(Context context) {
@@ -129,13 +127,16 @@ public class AppUtil {
     public static String convertToBitcoinCash(String address) {
         FormatsUtil f = FormatsUtil.getInstance();
         if (address != null && address.length() > 0 &&
-                (!f.isValidXpub(address) && f.isValidBitcoinAddress(address))) {
+                (!f.isValidXpub(address) && AddressUtil.isValidLegacy(address))) {
             try {
-                address = BitcoinCashURI.toCashAddress(address);
+                address = AddressUtil.toCashAddress(address);
             } catch (Exception e) {
                 e.printStackTrace();
             }
         }
+        /*
+        If it's not a valid legacy address from the if statement above, just return as the text we are sending.
+         */
         return address;
     }
 
@@ -146,7 +147,6 @@ public class AppUtil {
 
     public boolean hasValidReceiver() {
         String receiver = getReceivingAddress(context);
-        return FormatsUtil.getInstance().isValidBitcoinAddress(receiver)
-                || FormatsUtil.getInstance().isValidXpub(receiver);
+        return AddressUtil.isValidLegacy(receiver) || FormatsUtil.getInstance().isValidXpub(receiver);
     }
 }

--- a/app/src/main/java/com/bitcoin/merchant/app/util/AppUtil.java
+++ b/app/src/main/java/com/bitcoin/merchant/app/util/AppUtil.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.pm.PackageManager;
 
 import com.bitcoin.merchant.app.currency.CurrencyDetector;
+import com.github.kiulian.converter.AddressConverter;
 import com.google.bitcoin.uri.BitcoinCashURI;
 import com.google.gson.Gson;
 
@@ -121,6 +122,16 @@ public class AppUtil {
     }
 
     public static void setReceivingAddress(Context context, String receiver) {
+        /*
+        We keep the storage format as legacy for compatibility purposes.
+         */
+        if (AddressUtil.isValidCashAddr(receiver)) {
+            try {
+                receiver = AddressConverter.toLegacyAddress(receiver);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
         PrefsUtil.getInstance(context).setValue(PrefsUtil.MERCHANT_KEY_MERCHANT_RECEIVER, receiver);
     }
 

--- a/app/src/main/java/com/bitcoin/merchant/app/util/PrefsUtil.java
+++ b/app/src/main/java/com/bitcoin/merchant/app/util/PrefsUtil.java
@@ -15,6 +15,7 @@ public class PrefsUtil implements PersistantPrefs {
     public static final String MERCHANT_KEY_MERCHANT_NAME = "receiving_name";
     public static final String MERCHANT_KEY_MERCHANT_RECEIVER = "receiving_address";
     public static final String MERCHANT_KEY_SCANNED_ALL_MISSING_FUNDS = "scanned_for_missing_funds";
+    public static final String MERCHANT_KEY_XPUB_INDEX = "xpub_index";
     // unused public static final String MERCHANT_KEY_PUSH_NOTIFS = "push_notifications";
     public static final String MERCHANT_KEY_ACCOUNT_INDEX = "account_idx";
     private static Context context = null;

--- a/app/src/main/java/com/bitcoin/merchant/app/util/WalletUtil.java
+++ b/app/src/main/java/com/bitcoin/merchant/app/util/WalletUtil.java
@@ -81,7 +81,7 @@ public class WalletUtil {
     public WalletUtil(String xPub, Context context) throws Exception {
         this.xPub = xPub;
         this.context = context;
-        this.xpubIndex = !this.isSameXPub(this.xPub) ? 0 : PrefsUtil.getInstance(context).getValue(PrefsUtil.MERCHANT_KEY_XPUB_INDEX, 0);
+        this.xpubIndex = PrefsUtil.getInstance(context).getValue(PrefsUtil.MERCHANT_KEY_XPUB_INDEX + "_" + this.xPub, 0);
         DeterministicKey key = WalletUtil.createMasterPubKeyFromXPub(xPub);
         //This gets the receive chain from the xpub. If you want to generate change addresses, switch to 1 for the childNumber.
         this.accountKey = HDKeyDerivation.deriveChildKey(key, new ChildNumber(0, false));

--- a/app/src/main/java/com/github/kiulian/converter/b58/B58.java
+++ b/app/src/main/java/com/github/kiulian/converter/b58/B58.java
@@ -20,8 +20,8 @@ package com.github.kiulian.converter.b58;
  * -----------------------LICENSE_END-----------------------
  */
 
-import java.io.UnsupportedEncodingException;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 public class B58 {
@@ -65,11 +65,7 @@ public class B58 {
     }
 
     public static String encodeToStringChecked(byte[] input, byte[] version) {
-        try {
-            return new String(encodeToBytesChecked(input, version), "US-ASCII");
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);  // Cannot happen.
-        }
+        return new String(encodeToBytesChecked(input, version), StandardCharsets.US_ASCII);
     }
 
     public static byte[] encodeToBytesChecked(byte[] input, int version) {
@@ -89,11 +85,7 @@ public class B58 {
 
     public static String encodeToString(byte[] input) {
         byte[] output = encodeToBytes(input);
-        try {
-            return new String(output, "US-ASCII");
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);  // Cannot happen.
-        }
+        return new String(output, StandardCharsets.US_ASCII);
     }
 
     public static byte[] encodeToBytes(byte[] input) {
@@ -203,8 +195,8 @@ public class B58 {
         return new Decoded(foundVersion, bytes);
     }
 
-    private static byte[] decodeAndCheck(String input) {
-        byte buffer[] = decode(input);
+    public static byte[] decodeAndCheck(String input) {
+        byte[] buffer = decode(input);
         if (buffer.length < 4)
             throw new EncodingFormatException("Input too short");
         byte[] toHash = copyOfRange(buffer, 0, buffer.length - 4);

--- a/app/src/main/java/de/tobibrandt/bitcoincash/BitcoinCashAddressFormatter.java
+++ b/app/src/main/java/de/tobibrandt/bitcoincash/BitcoinCashAddressFormatter.java
@@ -1,0 +1,122 @@
+package de.tobibrandt.bitcoincash;
+
+import java.math.BigInteger;
+
+/**
+ * Copyright (c) 2018 Tobias Brandt
+ * <p>
+ * Distributed under the MIT software license, see the accompanying file LICENSE
+ * or http://www.opensource.org/licenses/mit-license.php.
+ */
+public class BitcoinCashAddressFormatter {
+
+    public static final String SEPARATOR = ":";
+
+    public static final String MAIN_NET_PREFIX = "bitcoincash";
+
+    private static final BigInteger[] POLYMOD_GENERATORS = new BigInteger[]{new BigInteger("98f2bc8e61", 16),
+            new BigInteger("79b76d99e2", 16), new BigInteger("f33e5fb3c4", 16), new BigInteger("ae2eabe2a8", 16),
+            new BigInteger("1e4f43e470", 16)};
+
+    private static final BigInteger POLYMOD_AND_CONSTANT = new BigInteger("07ffffffff", 16);
+
+    public static boolean isValidCashAddress(String bitcoinCashAddress) {
+        try {
+            if (bitcoinCashAddress == null || bitcoinCashAddress.length() == 0) {
+                return false;
+            }
+            String prefix;
+            if (bitcoinCashAddress.contains(SEPARATOR)) {
+                String[] split = bitcoinCashAddress.split(SEPARATOR);
+                if (split.length != 2) {
+                    return false;
+                }
+                prefix = split[0];
+                bitcoinCashAddress = split[1];
+                if (!MAIN_NET_PREFIX.equals(prefix.toLowerCase())) {
+                    return false;
+                }
+                if (!isSingleCase(prefix)) {
+                    return false;
+                }
+            } else {
+                prefix = MAIN_NET_PREFIX;
+            }
+            if (!isSingleCase(bitcoinCashAddress))
+                return false;
+            bitcoinCashAddress = bitcoinCashAddress.toLowerCase();
+            byte[] checksumData = concatenateByteArrays(
+                    concatenateByteArrays(getPrefixBytes(prefix), new byte[]{0x00}),
+                    BitcoinCashBase32.decode(bitcoinCashAddress));
+            byte[] calculateChecksumBytesPolymod = calculateChecksumBytesPolymod(checksumData);
+            return new BigInteger(calculateChecksumBytesPolymod).compareTo(BigInteger.ZERO) == 0;
+        } catch (RuntimeException re) {
+            return false;
+        }
+    }
+
+    private static boolean isSingleCase(String bitcoinCashAddress) {
+        if (bitcoinCashAddress.equals(bitcoinCashAddress.toLowerCase())) {
+            return true;
+        }
+        return bitcoinCashAddress.equals(bitcoinCashAddress.toUpperCase());
+    }
+
+    /**
+     * @param checksumInput
+     * @return Returns a 40 bits checksum in form of 5 8-bit arrays. This still has
+     * to me mapped to 5-bit array representation
+     */
+    private static byte[] calculateChecksumBytesPolymod(byte[] checksumInput) {
+        BigInteger c = BigInteger.ONE;
+        for (int i = 0; i < checksumInput.length; i++) {
+            byte c0 = c.shiftRight(35).byteValue();
+            c = c.and(POLYMOD_AND_CONSTANT).shiftLeft(5)
+                    .xor(new BigInteger(String.format("%02x", checksumInput[i]), 16));
+            if ((c0 & 0x01) != 0)
+                c = c.xor(POLYMOD_GENERATORS[0]);
+            if ((c0 & 0x02) != 0)
+                c = c.xor(POLYMOD_GENERATORS[1]);
+            if ((c0 & 0x04) != 0)
+                c = c.xor(POLYMOD_GENERATORS[2]);
+            if ((c0 & 0x08) != 0)
+                c = c.xor(POLYMOD_GENERATORS[3]);
+            if ((c0 & 0x10) != 0)
+                c = c.xor(POLYMOD_GENERATORS[4]);
+        }
+        byte[] checksum = c.xor(BigInteger.ONE).toByteArray();
+        if (checksum.length == 5) {
+            return checksum;
+        } else {
+            byte[] newChecksumArray = new byte[5];
+            System.arraycopy(checksum, Math.max(0, checksum.length - 5), newChecksumArray,
+                    Math.max(0, 5 - checksum.length), Math.min(5, checksum.length));
+            return newChecksumArray;
+        }
+
+    }
+
+    private static byte[] getPrefixBytes(String prefixString) {
+        byte[] prefixBytes = new byte[prefixString.length()];
+        char[] charArray = prefixString.toCharArray();
+        for (int i = 0; i < charArray.length; i++) {
+            prefixBytes[i] = (byte) (charArray[i] & 0x1f);
+        }
+        return prefixBytes;
+    }
+
+    /**
+     * Concatenates the two given byte arrays and returns the combined byte
+     * array.
+     *
+     * @param first
+     * @param second
+     * @return
+     */
+    private static byte[] concatenateByteArrays(byte[] first, byte[] second) {
+        byte[] concatenatedBytes = new byte[first.length + second.length];
+        System.arraycopy(first, 0, concatenatedBytes, 0, first.length);
+        System.arraycopy(second, 0, concatenatedBytes, first.length, second.length);
+        return concatenatedBytes;
+    }
+}

--- a/app/src/main/java/de/tobibrandt/bitcoincash/BitcoinCashBase32.java
+++ b/app/src/main/java/de/tobibrandt/bitcoincash/BitcoinCashBase32.java
@@ -1,0 +1,48 @@
+package de.tobibrandt.bitcoincash;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Copyright (c) 2018 Tobias Brandt
+ * <p>
+ * Distributed under the MIT software license, see the accompanying file LICENSE
+ * or http://www.opensource.org/licenses/mit-license.php.
+ */
+public class BitcoinCashBase32 {
+
+    public static final String CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
+
+    private static final char[] CHARS = CHARSET.toCharArray();
+
+    private static Map<Character, Integer> charPositionMap;
+
+    static {
+        charPositionMap = new HashMap<>();
+        for (int i = 0; i < CHARS.length; i++) {
+            charPositionMap.put(CHARS[i], i);
+        }
+        if (charPositionMap.size() != 32) {
+            throw new RuntimeException("The charset must contain 32 unique characters.");
+        }
+    }
+
+    /**
+     * Decode a base32 string back to the byte array representation
+     *
+     * @param base32String
+     * @return
+     */
+    public static byte[] decode(String base32String) {
+        byte[] bytes = new byte[base32String.length()];
+        char[] charArray = base32String.toCharArray();
+        for (int i = 0; i < charArray.length; i++) {
+            Integer position = charPositionMap.get(charArray[i]);
+            if (position == null) {
+                throw new RuntimeException("There seems to be an invalid char: " + charArray[i]);
+            }
+            bytes[i] = (byte) ((int) position);
+        }
+        return bytes;
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -57,7 +57,6 @@
 
 <!-- <string name="bitcoin_currency_symbol">&#xf15a;</string> -->
     <string name="bitcoin_currency_symbol">BCH</string>
-    <string name="enter_pin">Enter Pin</string>
     <string name="create_pin">Create Pin</string>
     <string name="confirm_pin">Confirm Pin</string>
     <string name="unrecognized_xpub">Unrecognized public key format</string>
@@ -93,10 +92,7 @@
     <string name="options_forget_payment_address_text">If you forget this payment address you will not be able to accept Bitcoin Cash payments until you add a new one.</string>
     <string name="options_receiving_payments">Receiving payments</string>
     <string name="options_new_payment_address">New payment address</string>
-    <string name="options_explain_payment_address">A payment address is a Bitcoin Cash address that you control or the extended public key (xPub) of your wallet.\n\nUsing the extended public key from your Wallet is the best way to set your payment address because it increases your privacy while making accounting easier by generating a new address for each transaction.</string>
     <string name="options_download_wallet">If you do not have a Bitcoin Cash wallet, create one for free by clicking here:\n\nhttps://wallet.bitcoin.com</string>
-    <string name="options_add_payment_address">Add payment address</string>
-    <string name="options_add_payment_address_text">You can use an Extended Public Key or any Bitcoin Cash address from your wallet. Paste or Scan the QR code displayed in your wallet.</string>
 
     <string name="scan">Scan</string>
     <string name="paste">Paste</string>
@@ -109,4 +105,22 @@
     <string name="pull_to_refresh_tap_label">Tap to refresh…</string>
     <string name="receive_coins_fragment_email_address_hint">Adresse e-mail</string>
     <string name="waiting_for_payment">Waiting For Payment</string>
+
+    <!--
+Translations needed
+-->
+    <string name="confirm_request">Checkout</string>
+    <string name="cancel">Cancel</string>
+    <string name="done">Done</string>
+    <string name="powered_by">Powered by</string>
+    <string name="bitcoindotcom">Bitcoin.com</string>
+    <string name="enter_pin">Enter passcode</string>
+    <string name="syncing_xpub">Syncing xpub…</string>
+    <string name="synced_xpub">xpub synced!</string>
+    <string name="about_title">About</string>
+    <string name="no_history_text">This Cash Register does not have a transaction history.</string>
+    <string name="options_explain_payment_address">A destination address can either be a Bitcoin Cash address or Extended Public Key</string>
+    <string name="options_add_payment_address">Add destination address</string>
+    <string name="options_add_payment_address_text">You can use any Bitcoin Cash address from your wallet or an Extended Public Key</string>
+    <string name="save">Save</string>
 </resources>


### PR DESCRIPTION
This PR fixes various internal bugs and UX issues.

- The address setting dialog now displays cashaddr addresses instead of legacy.
- Address validation is fixed as it now uses a different library for validating cashaddrs. Beforehand, you could remove certain parts of a cashaddr address and the app would think it's valid when it was invalid.
- extended public key (xpub) address generation system has been completely rewritten so derivation paths besides m/0' can be supported. beforehand it used bitcoinj's wallet system, which would check to see if the derivation path was m/0', if it was not then BCR could not generate an address. See bug report here: https://www.reddit.com/r/btc/comments/dha9gg/bar_owner_overhears_me_talking_about_bitcoincash/f3leqjh/
- socket connection fix: if the socket failed to connect before, it would simply not connect at all. now it loops until it is successfully connected.