### PR TITLE
Bugfix: the transaction confirmation screen does not appear when using XPUB address

### DIFF
--- a/app/src/main/java/com/bitcoin/merchant/app/screens/PaymentRequestFragment.kt
+++ b/app/src/main/java/com/bitcoin/merchant/app/screens/PaymentRequestFragment.kt
@@ -358,7 +358,8 @@ class PaymentRequestFragment : ToolbarAwareFragment() {
                 // then addresses can be reused. Address reuse is not an issue
                 // because the BIP-70 server is the one only broadcasting the TX to that address
                 // and thus it is aware of which invoice is being paid without possible confusion
-                i.address = app.wallet.getAddressFromXPubAndMoveToNext()
+                val address = app.wallet.getAddressFromXPubAndMoveToNext()
+                i.address = AddressUtil.toCashAddress(address)
                 Log.i(TAG, "BCH-address(xPub) to receive: " + i.address)
             } catch (e: Exception) {
                 Analytics.error_generate_address_from_xpub.sendError(e)


### PR DESCRIPTION
XPUB addresses are now handled similarly to legacy address, i.e. they are now converted to cash addresses. The transaction complete screen now appears and the transaction will be visible in the Transactions history screen.